### PR TITLE
fix PHP 8.0 ValueError: fread(): Argument #2 ($length) must be greater than 0

### DIFF
--- a/lib/Horde/Stream/Wrapper/Combine.php
+++ b/lib/Horde/Stream/Wrapper/Combine.php
@@ -171,9 +171,11 @@ class Horde_Stream_Wrapper_Combine
             }
 
             $curr_read = min($count, $tmp['l'] - $tmp['p']);
-            $out .= fread($tmp['fp'], $curr_read);
-            $count -= $curr_read;
-            $this->_position += $curr_read;
+            if ($curr_read > 0) {
+                $out .= fread($tmp['fp'], $curr_read);
+                $count -= $curr_read;
+                $this->_position += $curr_read;
+            }
 
             if ($this->_position == $this->_length) {
                 if ($count) {


### PR DESCRIPTION
Backport upstream fix : https://github.com/horde/Stream_Wrapper/pull/1